### PR TITLE
fix: implement atomic stock reservation and redis-db sync #1

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,13 @@ generator client {
 }
 
 // Data Model
+model Product {
+  id        String   @id @default(cuid()) // Unique ID for each product
+  name      String   // Name of the product (e.g., "iPhone")
+  stock     Int      // Available stock for the product
+  createdAt DateTime @default(now()) // Timestamp when the product was created
+}
+
 model Order {
   id         Int      @id @default(autoincrement()) // Unique ID for each order, automatically increments
   productId  String    // ID of item being bought ( "iphone")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,56 @@
+/**
+ * @file seed.ts
+ * @description Data Seeding / Environment Provisioning Script.
+ * This file ensures the initial state of the database is correct before the application logic begins.
+ * Seeds initial product data into the PostgreSQL database via Prisma Client.
+ * @howto Run: npx prisma db seed
+ *  - Verify package.json has this config:
+ *      "prisma": { "seed": "ts-node prisma/seed.ts" }
+ *  - Execute command: npx prisma db seed
+ *  - Purpose: Resets/initializes product stock in PostgreSQL so the OrderWorker has data to process.
+ */ 
+
+import { PrismaClient } from '../src/generated/prisma';
+import { Pool } from 'pg';
+import { PrismaPg } from '@prisma/adapter-pg';
+import 'dotenv/config';
+import Redis from 'ioredis';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const adapter = new PrismaPg(pool);
+const prisma = new PrismaClient({ adapter });
+
+// This tells Redis to connect to the specified URL from env or default to localhost, to talk to our Redis container.
+const redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
+
+async function main() {
+    // Seed initial products
+    const products = [
+        { id: 'iphone', name: 'iPhone 15', stock: 20 },
+        { id: 'macbook', name: 'MacBook Pro', stock: 10 },
+    ];
+
+    // Upsert products to ensure idempotent seeding. This will create the product if it doesn't exist,
+    // or update the stock if it does.
+    for (const product of products) {
+        // asyncronous opeation
+        await prisma.product.upsert({
+            where: { id: product.id },
+            update: { stock: product.stock }, // Reset stock on every seed
+            create: product,
+        });
+
+        // Also set initial stock in Redis for fast access, using the same stock value
+        await redis.set(`stock:${product.id}`, product.stock);
+    }
+
+    console.log('✅ Database seeded with initial products.');
+}
+
+main()
+    // Handling the Promise Lifecycle
+    .catch((e) => { console.error(e); process.exit(1); })
+    .finally(async () => { 
+        await prisma.$disconnect();
+        await redis.quit(); // Closing Redis connection
+    }); // Closing the connect pool

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -16,6 +16,7 @@ export interface ReserveStockResponse {
 
 export class OrderService {
     static async reserveStock(productId: string, quantity: number) {
+       
         // substracts the amount immediately (atomic)
         const newStock = await redis.decrby(`stock:${productId}`, quantity);
 
@@ -26,9 +27,12 @@ export class OrderService {
             return { success: false, message: "Insufficient stock" };
         }
 
-        // If stock reservation is successful, enqueue a job to persist the order
         await addOrderToQueue({ productId, quantity });
 
-        return { success: true, newStock };
+        return { 
+            success: true,
+            message: "Order queued successfully", 
+            newStock: newStock 
+        };
     }
 }


### PR DESCRIPTION
PR resolves issue #1.

**Changes**

**Atomic Stock Reservation:** Refactored orderService.ts to use Redis DECRBY. This ensures that stock is "locked" at the network level before a job is ever queued, preventing overselling.

**Worker Reconciliation:** Updated orderWorker.ts to perform a final sync. After a successful PostgreSQL transaction, the worker overwrites the Redis key with the "Source of Truth" from the DB.

**Transactional Safety:** Implemented a stock-level check inside the Prisma $transaction. If Postgres hits a negative value, the transaction rolls back, ensuring data integrity.

**Seed Script:** Updated prisma/seed.ts to initialize both Postgres and Redis values in a single command.

**Verification Results**

- [x] Verified npx prisma db seed correctly resets both DB and Cache.

- [x] Verified that buying the final item (stock 20 -> 0) returns a success.

- [x] Verified that attempting to buy stock when Redis is at 0 returns Insufficient stock without hitting the DB.

- [x] Verified that manual Redis changes are corrected by the Worker during the next successful transaction.